### PR TITLE
Update the list of packages to install

### DIFF
--- a/providers_ibm.md
+++ b/providers_ibm.md
@@ -98,7 +98,11 @@ Before you begin, [create a {{site.data.keyword.satelliteshort}} location](/docs
     {: pre}
 
     ```sh
-    subscription-manager repos --enable=*
+    subscription-manager repos --enable rhel-server-rhscl-7-rpms
+    subscription-manager repos --enable rhel-7-server-optional-rpms
+    subscription-manager repos --enable rhel-7-server-rh-common-rpms
+    subscription-manager repos --enable rhel-7-server-supplementary-rpms
+    subscription-manager repos --enable rhel-7-server-extras-rpms
     ```
     {: pre}
 


### PR DESCRIPTION
The attach_host scrip is not working any more if you keep enable=*.

The line `subscription-manager repos --enable=*` will throw the following error:
`One of the configured repositories failed (RHEL for SAP (for RHEL 7 Server) Update Services for SAP Solutions (RPMs)),`

It is recommended to pass the list of packages required as this is stated for the other cloud.
https://cloud.ibm.com/docs/satellite?topic=satellite-host-reqs#reqs-host-packages

@artberger